### PR TITLE
feat: self-cleanup migrate-repo-template wf yml without PAT needing '…

### DIFF
--- a/.github/workflows/0.initial.migrate-repo-template.yml
+++ b/.github/workflows/0.initial.migrate-repo-template.yml
@@ -77,15 +77,6 @@ jobs:
           PACKAGE_NEW: ${{ inputs.package }}
           INPUT_EMAIL: ${{ inputs.email }}
         run: |
-          echo "GITHUB_REPOSITORY_OLD: $GITHUB_REPOSITORY_OLD"
-          echo "GITHUB_REPOSITORY_NAME: $GITHUB_REPOSITORY_NAME"
-          echo "ARTIFACT_GROUP_OLD: $ARTIFACT_GROUP_OLD"
-          echo "ARTIFACT_GROUP_NEW: $ARTIFACT_GROUP_NEW"
-          echo "ARTIFACT_NAME_OLD: $ARTIFACT_NAME_OLD"
-          echo "ARTIFACT_NAME_NEW: $ARTIFACT_NAME_NEW"
-          echo "PACKAGE_OLD: $PACKAGE_OLD"
-          echo "PACKAGE_NEW: $PACKAGE_NEW"
-          
           # gradle files
           ## gradle.properties - initial version 
           echo "version=0.0.1-SNAPSHOT" > gradle.properties
@@ -122,9 +113,6 @@ jobs:
           #find $ARTIFACT_NAME_NEW -type f -name "*.java" -print0 | xargs -0 sed -i '' -e "s@$PACKAGE_OLD@$PACKAGE_NEW@g"
           find $ARTIFACT_NAME_NEW -type f -name "*.java"  -exec sed -i'' -e "s@$PACKAGE_OLD@$PACKAGE_NEW@g" {} +
 
-          # GitHub actions
-          sed -i "s/$ARTIFACT_NAME_OLD/$ARTIFACT_NAME_NEW/g" .github/workflows/callable.publish-javadoc.yml
-          
           # README from template
           mv -f .github/template/README.md README.md
           rm -Rf .github/template/

--- a/.github/workflows/callable.publish-javadoc.yml
+++ b/.github/workflows/callable.publish-javadoc.yml
@@ -34,10 +34,13 @@ jobs:
             echo "PUBLISH_VERSION=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
           fi
 
+      - name: Conclude library name and set env
+        run: echo "LIBRARY_NAME=$(grep -o '^rootProject.name.*' settings.gradle.kts | sed -e 's/rootProject.name.*"\(.*\)"/\1/')" >> $GITHUB_ENV
+
       - name: Deploy to GitHub Page 🚀 with Gradle
         uses: JamesIves/github-pages-deploy-action@v4.4.3
         with:
           branch: gh-pages
           clean: true
-          folder: java-library-template/build/docs/javadoc
+          folder: ${{ env.LIBRARY_NAME }}/build/docs/javadoc
           target-folder: javadoc/${{ env.PUBLISH_VERSION }}


### PR DESCRIPTION
…actions' write permissions

With this change 'actions' permission is no longer needed.

GitHub Actions workflows can delete (and commit+push) itself, but not modify other wfs without 'actions' r/w permission granted.