### PR TITLE
fix: main cicd pipeline - run javadoc also on push (main)

### DIFF
--- a/.github/workflows/1.pipeline.yml
+++ b/.github/workflows/1.pipeline.yml
@@ -80,5 +80,5 @@ jobs:
     if: |
       (
         github.ref == 'refs/heads/main'
-        && inputs.type == '...no release'
+        && ( inputs.type == '' || inputs.type == '...no release' )
       ) || github.ref_type == 'tag' 


### PR DESCRIPTION
<!-- ☝️ PR title should follow conventional commits (https://conventionalcommits.org) -->
<!-- Thanks for taking the time to write this Pull Request! ❤️ -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description, Motivation and Context

Fixes condition for CICD main workflow, javadoc jobs to also run on push to main branch.

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 🧪 How Has This Been Tested?

<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
